### PR TITLE
Configure image CI pipelines

### DIFF
--- a/images.CI/azure-pipelines/image-generation.yml
+++ b/images.CI/azure-pipelines/image-generation.yml
@@ -1,6 +1,10 @@
 jobs:
 - job:
   pool: ci-agent-pool
+  timeoutInMinutes: 600
+  variables:
+  - group: Image Generation Variables
+
   steps:
   - task: PowerShell@2
     displayName: 'Build VM'

--- a/images.CI/azure-pipelines/image-generation.yml
+++ b/images.CI/azure-pipelines/image-generation.yml
@@ -2,8 +2,12 @@ jobs:
 - job:
   pool: ci-agent-pool
   steps:
-  - script: |
-      ./images.CI/build-image.ps1 -ResourcesNamePrefix $(Build.BuildNumber) `
+  - task: PowerShell@2
+    displayName: 'Build VM'
+    inputs:
+      targetType: filePath
+      filePath: ./images.CI/build-image.ps1
+      arguments: -ResourcesNamePrefix $(Build.BuildNumber) `
                         -ClientId $(CLIENT_ID) `
                         -ClientSecret $(CLIENT_SECRET) `
                         -Image ${{ parameters.image_type }} `
@@ -16,14 +20,16 @@ jobs:
                         -VirtualNetworkRG $(BUILD_AGENT_VNET_RESOURCE_GROUP) `
                         -VirtualNetworkSubnet $(BUILD_AGENT_SUBNET_NAME) `
                         -GitHubFeedToken $(GITHUB_TOKEN)
-    displayName: Build VM
 
-  - script: |
-      ./images.CI/cleanup.ps1 -ResourcesNamePrefix $(Build.BuildNumber) `
+  - task: PowerShell@2
+    displayName: 'Clean up resources'
+    condition: always()
+    inputs:
+      targetType: filePath
+      filePath: ./images.CI/cleanup.ps1
+      arguments: -ResourcesNamePrefix $(Build.BuildNumber) `
                      -ClientId $(CLIENT_ID) `
                      -ClientSecret $(CLIENT_SECRET) `
                      -Image ${{ parameters.image_type }} `
                      -SubscriptionId $(AZURE_SUBSCRIPTION) `
                      -TenantId $(AZURE_TENANT)
-    displayName: Clean up resources
-    condition: always()

--- a/images.CI/azure-pipelines/image-generation.yml
+++ b/images.CI/azure-pipelines/image-generation.yml
@@ -1,0 +1,29 @@
+jobs:
+- job:
+  pool: ci-agent-pool
+  steps:
+  - script: |
+      ./images.CI/build-image.ps1 -ResourcesNamePrefix $(Build.BuildNumber) `
+                        -ClientId $(CLIENT_ID) `
+                        -ClientSecret $(CLIENT_SECRET) `
+                        -Image ${{ parameters.image_type }} `
+                        -ResourceGroup $(AZURE_RESOURCE_GROUP) `
+                        -StorageAccount $(AZURE_STORAGE_ACCOUNT) `
+                        -SubscriptionId $(AZURE_SUBSCRIPTION) `
+                        -TenantId $(AZURE_TENANT) `
+                        -Location $(AZURE_LOCATION) `
+                        -VirtualNetworkName $(BUILD_AGENT_VNET_NAME) `
+                        -VirtualNetworkRG $(BUILD_AGENT_VNET_RESOURCE_GROUP) `
+                        -VirtualNetworkSubnet $(BUILD_AGENT_SUBNET_NAME) `
+                        -GitHubFeedToken $(GITHUB_TOKEN)
+    displayName: Build VM
+
+  - script: |
+      ./images.CI/cleanup.ps1 -ResourcesNamePrefix $(Build.BuildNumber) `
+                     -ClientId $(CLIENT_ID) `
+                     -ClientSecret $(CLIENT_SECRET) `
+                     -Image ${{ parameters.image_type }} `
+                     -SubscriptionId $(AZURE_SUBSCRIPTION) `
+                     -TenantId $(AZURE_TENANT)
+    displayName: Clean up resources
+    condition: always()

--- a/images.CI/azure-pipelines/ubuntu1604.yml
+++ b/images.CI/azure-pipelines/ubuntu1604.yml
@@ -6,9 +6,6 @@
 #     - master
 #   always: true
 
-variables:
-- group: "Image Generation Variables"
-
 trigger: none
 pr:
   autoCancel: true

--- a/images.CI/azure-pipelines/ubuntu1604.yml
+++ b/images.CI/azure-pipelines/ubuntu1604.yml
@@ -1,0 +1,22 @@
+# schedules:
+# - cron: "0 0 * * *"
+#   displayName: Daily
+#   branches:
+#     include:
+#     - master
+#   always: true
+
+variables:
+- group: "Image Generation Variables"
+
+trigger: none
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - master
+
+jobs:
+- template: image-generation.yml
+  parameters:
+    image_type: ubuntu1604

--- a/images.CI/azure-pipelines/ubuntu1804.yml
+++ b/images.CI/azure-pipelines/ubuntu1804.yml
@@ -1,0 +1,22 @@
+# schedules:
+# - cron: "0 0 * * *"
+#   displayName: Daily
+#   branches:
+#     include:
+#     - master
+#   always: true
+
+variables:
+- group: "Image Generation Variables"
+
+trigger: none
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - master
+
+jobs:
+- template: image-generation.yml
+  parameters:
+    image_type: ubuntu1804

--- a/images.CI/azure-pipelines/ubuntu1804.yml
+++ b/images.CI/azure-pipelines/ubuntu1804.yml
@@ -6,9 +6,6 @@
 #     - master
 #   always: true
 
-variables:
-- group: "Image Generation Variables"
-
 trigger: none
 pr:
   autoCancel: true

--- a/images.CI/azure-pipelines/windows2016.yml
+++ b/images.CI/azure-pipelines/windows2016.yml
@@ -6,9 +6,6 @@
 #     - master
 #   always: true
 
-variables:
-- group: "Image Generation Variables"
-
 trigger: none
 pr:
   autoCancel: true

--- a/images.CI/azure-pipelines/windows2016.yml
+++ b/images.CI/azure-pipelines/windows2016.yml
@@ -1,0 +1,22 @@
+# schedules:
+# - cron: "0 0 * * *"
+#   displayName: Daily
+#   branches:
+#     include:
+#     - master
+#   always: true
+
+variables:
+- group: "Image Generation Variables"
+
+trigger: none
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - master
+
+jobs:
+- template: image-generation.yml
+  parameters:
+    image_type: Windows2016-Azure

--- a/images.CI/azure-pipelines/windows2019.yml
+++ b/images.CI/azure-pipelines/windows2019.yml
@@ -1,0 +1,22 @@
+# schedules:
+# - cron: "0 0 * * *"
+#   displayName: Daily
+#   branches:
+#     include:
+#     - master
+#   always: true
+
+variables:
+- group: "Image Generation Variables"
+
+trigger: none
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - master
+
+jobs:
+- template: image-generation.yml
+  parameters:
+    image_type: Windows2019-Azure

--- a/images.CI/azure-pipelines/windows2019.yml
+++ b/images.CI/azure-pipelines/windows2019.yml
@@ -6,9 +6,6 @@
 #     - master
 #   always: true
 
-variables:
-- group: "Image Generation Variables"
-
 trigger: none
 pr:
   autoCancel: true

--- a/images.CI/build-image.ps1
+++ b/images.CI/build-image.ps1
@@ -15,7 +15,7 @@ param(
 )
 
 $TemplatePath = (Get-ChildItem -Path "images" -Include "$Image.json" -Recurse -Depth 2).FullName
-if ($TemplatePath -eq $null)
+if (-not $TemplatePath)
 {
     Write-Error "'-Image' parameter is not valid. You have to specify correct image type."
     exit 1

--- a/images.CI/build-image.ps1
+++ b/images.CI/build-image.ps1
@@ -19,10 +19,6 @@ $TemplatePath = (Get-ChildItem -Path "images" -Include "$Image.json" -Recurse -D
 $TempResourceGroupName = "${ResourcesNamePrefix}_${Image}"
 $InstallPassword = [System.GUID]::NewGuid().ToString().ToUpper()
 
-Write-Host "TemplatePath = $TemplatePath"
-Write-Host "ResourcesNamePrefix = $ResourcesNamePrefix"
-Write-Host "TempResourceGroupName = $TempResourceGroupName"
-
 Write-Host "Build $Image VM"
 packer build    -var "capture_name_prefix=$ResourcesNamePrefix" `
                 -var "client_id=$ClientId" `

--- a/images.CI/build-image.ps1
+++ b/images.CI/build-image.ps1
@@ -1,0 +1,41 @@
+param(
+    [ValidateSet('Windows2019-Azure','Windows2016-Azure','ubuntu1604','ubuntu1804')]
+    [String] [Parameter (Mandatory=$true)] $Image,
+    [String] [Parameter (Mandatory=$true)] $ClientId,
+    [String] [Parameter (Mandatory=$true)] $ClientSecret,
+    [String] [Parameter (Mandatory=$true)] $GitHubFeedToken,
+    [String] [Parameter (Mandatory=$true)] $ResourcesNamePrefix,
+    [String] [Parameter (Mandatory=$true)] $Location,
+    [String] [Parameter (Mandatory=$true)] $ResourceGroup,
+    [String] [Parameter (Mandatory=$true)] $StorageAccount,
+    [String] [Parameter (Mandatory=$true)] $SubscriptionId,
+    [String] [Parameter (Mandatory=$true)] $TenantId,
+    [String] [Parameter (Mandatory=$true)] $VirtualNetworkName,
+    [String] [Parameter (Mandatory=$true)] $VirtualNetworkRG,
+    [String] [Parameter (Mandatory=$true)] $VirtualNetworkSubnet
+)
+
+$TemplatePath = (Get-ChildItem -Path "images" -Include "$Image.json" -Recurse -Depth 2).FullName
+$TempResourceGroupName = "${ResourcesNamePrefix}_${Image}"
+$InstallPassword = [System.GUID]::NewGuid().ToString().ToUpper()
+
+Write-Host "TemplatePath = $TemplatePath"
+Write-Host "ResourcesNamePrefix = $ResourcesNamePrefix"
+Write-Host "TempResourceGroupName = $TempResourceGroupName"
+
+Write-Host "Build $Image VM"
+packer build    -var "capture_name_prefix=$ResourcesNamePrefix" `
+                -var "client_id=$ClientId" `
+                -var "client_secret=$ClientSecret" `
+                -var "install_password=$InstallPassword" `
+                -var "github_feed_token=$GitHubFeedToken" `
+                -var "location=$Location" `
+                -var "resource_group=$ResourceGroup" `
+                -var "storage_account=$StorageAccount" `
+                -var "subscription_id=$SubscriptionId" `
+                -var "temp_resource_group_name=$TempResourceGroupName" `
+                -var "tenant_id=$TenantId" `
+                -var "virtual_network_name=$VirtualNetworkName" `
+                -var "virtual_network_resource_group_name=$VirtualNetworkRG" `
+                -var "virtual_network_subnet_name=$VirtualNetworkSubnet" `
+                $TemplatePath

--- a/images.CI/build-image.ps1
+++ b/images.CI/build-image.ps1
@@ -1,5 +1,4 @@
 param(
-    [ValidateSet('Windows2019-Azure','Windows2016-Azure','ubuntu1604','ubuntu1804')]
     [String] [Parameter (Mandatory=$true)] $Image,
     [String] [Parameter (Mandatory=$true)] $ClientId,
     [String] [Parameter (Mandatory=$true)] $ClientSecret,
@@ -16,8 +15,16 @@ param(
 )
 
 $TemplatePath = (Get-ChildItem -Path "images" -Include "$Image.json" -Recurse -Depth 2).FullName
+if ($TemplatePath -eq $null)
+{
+    Write-Error "'-Image' parameter is not valid. You have to specify correct image type."
+    exit 1
+}
+
 $TempResourceGroupName = "${ResourcesNamePrefix}_${Image}"
 $InstallPassword = [System.GUID]::NewGuid().ToString().ToUpper()
+
+packer validate -syntax-only $TemplatePath
 
 Write-Host "Build $Image VM"
 packer build    -var "capture_name_prefix=$ResourcesNamePrefix" `

--- a/images.CI/cleanup.ps1
+++ b/images.CI/cleanup.ps1
@@ -1,0 +1,25 @@
+param(
+    [ValidateSet('Windows2019-Azure','Windows2016-Azure','ubuntu1604','ubuntu1804')]
+    [String] [Parameter (Mandatory=$true)] $Image,
+    [String] [Parameter (Mandatory=$true)] $ResourcesNamePrefix,
+    [String] [Parameter (Mandatory=$true)] $ClientId,
+    [String] [Parameter (Mandatory=$true)] $ClientSecret,
+    [String] [Parameter (Mandatory=$true)] $SubscriptionId,
+    [String] [Parameter (Mandatory=$true)] $TenantId
+)
+
+az login --service-principal --username $ClientId --password $ClientSecret --tenant $TenantId | Out-Null
+
+$TempResourceGroupName = "${ResourcesNamePrefix}_${Image}"
+
+Write-Host "ResourcesNamePrefix = $ResourcesNamePrefix"
+Write-Host "TempResourceGroupName = $TempResourceGroupName"
+
+$groupExist = az group exists --name $TempResourceGroupName --subscription $SubscriptionId | Out-Null
+if ($groupExist -eq "true") {
+    Write-Host "Found a match, deleting temporary files"
+    az group delete --name $TempResourceGroupName --subscription $SubscriptionId --yes | Out-Null
+    Write-Host "Temporary group was deleted succesfully" -ForegroundColor Green
+} else {
+    Write-Host "No temporary groups found"
+}

--- a/images.CI/cleanup.ps1
+++ b/images.CI/cleanup.ps1
@@ -1,5 +1,4 @@
 param(
-    [ValidateSet('Windows2019-Azure','Windows2016-Azure','ubuntu1604','ubuntu1804')]
     [String] [Parameter (Mandatory=$true)] $Image,
     [String] [Parameter (Mandatory=$true)] $ResourcesNamePrefix,
     [String] [Parameter (Mandatory=$true)] $ClientId,

--- a/images.CI/cleanup.ps1
+++ b/images.CI/cleanup.ps1
@@ -12,9 +12,6 @@ az login --service-principal --username $ClientId --password $ClientSecret --ten
 
 $TempResourceGroupName = "${ResourcesNamePrefix}_${Image}"
 
-Write-Host "ResourcesNamePrefix = $ResourcesNamePrefix"
-Write-Host "TempResourceGroupName = $TempResourceGroupName"
-
 $groupExist = az group exists --name $TempResourceGroupName --subscription $SubscriptionId | Out-Null
 if ($groupExist -eq "true") {
     Write-Host "Found a match, deleting temporary files"


### PR DESCRIPTION
We've prepared `build-image.ps1` and `cleanup.ps1` scripts and implemented yml definitions for the following images:
- `Ubuntu1604`;
- `Ubuntu1804`;
- `Windows2016`;
- `Windows2019`.