### PR TITLE
Cut sensitive data from packer logs

### DIFF
--- a/images.CI/build-image.ps1
+++ b/images.CI/build-image.ps1
@@ -26,13 +26,15 @@ $InstallPassword = [System.GUID]::NewGuid().ToString().ToUpper()
 
 packer validate -syntax-only $TemplatePath
 
-$SensitiveData = @('OSType',
-                    'StorageAccountLocation',
-                    'OSDiskUri',
-                    'OSDiskUriReadOnlySas',
-                    'TemplateUri',
-                    'TemplateUriReadOnlySas',
-                    ':  ->')
+$SensitiveData = @(
+    'OSType',
+    'StorageAccountLocation',
+    'OSDiskUri',
+    'OSDiskUriReadOnlySas',
+    'TemplateUri',
+    'TemplateUriReadOnlySas',
+    ':  ->'
+)
 
 Write-Host "Build $Image VM"
 packer build    -var "capture_name_prefix=$ResourcesNamePrefix" `

--- a/images.CI/build-image.ps1
+++ b/images.CI/build-image.ps1
@@ -26,7 +26,13 @@ $InstallPassword = [System.GUID]::NewGuid().ToString().ToUpper()
 
 packer validate -syntax-only $TemplatePath
 
-$SensitiveData = @('OSType', 'StorageAccountLocation', 'OSDiskUri', 'OSDiskUriReadOnlySas', 'TemplateUri', 'TemplateUriReadOnlySas', ':  ->')
+$SensitiveData = @('OSType',
+                    'StorageAccountLocation',
+                    'OSDiskUri',
+                    'OSDiskUriReadOnlySas',
+                    'TemplateUri',
+                    'TemplateUriReadOnlySas',
+                    ':  ->')
 
 Write-Host "Build $Image VM"
 packer build    -var "capture_name_prefix=$ResourcesNamePrefix" `
@@ -47,6 +53,6 @@ packer build    -var "capture_name_prefix=$ResourcesNamePrefix" `
         | Where-Object {
             #Filter sensitive data from Packer logs
             $currentString = $_
-            $matchedString = $SensitiveData | Where-Object { $currentString -match $_ }
-            return $matchedString -eq $null
+            $sensitiveString = $SensitiveData | Where-Object { $currentString -match $_ }
+            $sensitiveString -eq $null
         }

--- a/images.CI/build-image.ps1
+++ b/images.CI/build-image.ps1
@@ -26,6 +26,8 @@ $InstallPassword = [System.GUID]::NewGuid().ToString().ToUpper()
 
 packer validate -syntax-only $TemplatePath
 
+$SensitiveData = @('OSType', 'StorageAccountLocation', 'OSDiskUri', 'OSDiskUriReadOnlySas', 'TemplateUri', 'TemplateUriReadOnlySas', ':  ->')
+
 Write-Host "Build $Image VM"
 packer build    -var "capture_name_prefix=$ResourcesNamePrefix" `
                 -var "client_id=$ClientId" `
@@ -41,4 +43,10 @@ packer build    -var "capture_name_prefix=$ResourcesNamePrefix" `
                 -var "virtual_network_name=$VirtualNetworkName" `
                 -var "virtual_network_resource_group_name=$VirtualNetworkRG" `
                 -var "virtual_network_subnet_name=$VirtualNetworkSubnet" `
-                $TemplatePath
+                $TemplatePath `
+        | Where-Object {
+            #Filter sensitive data from Packer logs
+            $currentString = $_
+            $matchedString = $SensitiveData | Where-Object { $currentString -match $_ }
+            return $matchedString -eq $null
+        }


### PR DESCRIPTION
In scope of this PR we've added filter which removes sensitive data from Packer logs