### PR TITLE
Add ability to run CI build on custom repository

### DIFF
--- a/images.CI/azure-pipelines/image-generation.yml
+++ b/images.CI/azure-pipelines/image-generation.yml
@@ -6,6 +6,13 @@ jobs:
   - group: Image Generation Variables
 
   steps:
+  - pwsh: |
+      Remove-Item -path './*' -Recurse -Force
+      Write-Host "Download $(BRANCH_NAME) branch from $(IMAGE_GEN_REPO_URI)"
+      git clone $(IMAGE_GEN_REPO_URI) . -b $(BRANCH_NAME) --single-branch --depth 1
+    displayName: 'Download custom repository'
+    condition: and(ne(variables['BRANCH_NAME'], ''), ne(variables['IMAGE_GEN_REPO_URI'], ''))
+
   - task: PowerShell@2
     displayName: 'Build VM'
     inputs:

--- a/images.CI/azure-pipelines/image-generation.yml
+++ b/images.CI/azure-pipelines/image-generation.yml
@@ -6,7 +6,7 @@ jobs:
   - group: Image Generation Variables
 
   steps:
-  - pwsh: |
+  - powershell: |
       Remove-Item -path './*' -Recurse -Force
       Write-Host "Download $(BRANCH_NAME) branch from $(IMAGE_GEN_REPO_URI)"
       git clone $(IMAGE_GEN_REPO_URI) . -b $(BRANCH_NAME) --single-branch --depth 1

--- a/images.CI/azure-pipelines/image-generation.yml
+++ b/images.CI/azure-pipelines/image-generation.yml
@@ -6,12 +6,15 @@ jobs:
   - group: Image Generation Variables
 
   steps:
-  - powershell: |
-      Remove-Item -path './*' -Recurse -Force
-      Write-Host "Download $(CUSTOM_REPOSITORY_BRANCH) branch from $(CUSTOM_REPOSITORY_URL)"
-      git clone $(CUSTOM_REPOSITORY_URL) . -b $(CUSTOM_REPOSITORY_BRANCH) --single-branch --depth 1
+  - task: PowerShell@2
     displayName: 'Download custom repository'
     condition: and(ne(variables['CUSTOM_REPOSITORY_BRANCH'], ''), ne(variables['CUSTOM_REPOSITORY_URL'], ''))
+    inputs:
+      targetType: 'inline'
+      script: |
+        Remove-Item -path './*' -Recurse -Force
+        Write-Host "Download $(CUSTOM_REPOSITORY_BRANCH) branch from $(CUSTOM_REPOSITORY_URL)"
+        git clone $(CUSTOM_REPOSITORY_URL) . -b $(CUSTOM_REPOSITORY_BRANCH) --single-branch --depth 1
 
   - task: PowerShell@2
     displayName: 'Build VM'

--- a/images.CI/azure-pipelines/image-generation.yml
+++ b/images.CI/azure-pipelines/image-generation.yml
@@ -8,10 +8,10 @@ jobs:
   steps:
   - powershell: |
       Remove-Item -path './*' -Recurse -Force
-      Write-Host "Download $(BRANCH_NAME) branch from $(IMAGE_GEN_REPO_URI)"
-      git clone $(IMAGE_GEN_REPO_URI) . -b $(BRANCH_NAME) --single-branch --depth 1
+      Write-Host "Download $(CUSTOM_REPOSITORY_BRANCH) branch from $(CUSTOM_REPOSITORY_URL)"
+      git clone $(CUSTOM_REPOSITORY_URL) . -b $(CUSTOM_REPOSITORY_BRANCH) --single-branch --depth 1
     displayName: 'Download custom repository'
-    condition: and(ne(variables['BRANCH_NAME'], ''), ne(variables['IMAGE_GEN_REPO_URI'], ''))
+    condition: and(ne(variables['CUSTOM_REPOSITORY_BRANCH'], ''), ne(variables['CUSTOM_REPOSITORY_URL'], ''))
 
   - task: PowerShell@2
     displayName: 'Build VM'


### PR DESCRIPTION
In scope of this PR we've added an additional `powershell` step in order to download custom repository by specifying the `CUSTOM_REPOSITORY_URL ` and `CUSTOM_REPOSITORY_BRANCH ` variables in the pipeline configuration.