### PR TITLE
Enable Docker

### DIFF
--- a/images/win/scripts/Installers/Install-Docker.ps1
+++ b/images/win/scripts/Installers/Install-Docker.ps1
@@ -5,13 +5,12 @@
 ##         can continue.
 ################################################################################
 
-# TO-DO: Will be fixed with https://github.com/actions/virtual-environments-internal/issues/2512
-# Write-Host "Install-Package Docker"
-# Install-Package -Name docker -ProviderName DockerMsftProvider -Force
-# Start-Service docker
+Write-Host "Install-Package Docker"
+Install-Package -Name docker -ProviderName DockerMsftProvider -Force
+Start-Service docker
 
-# Write-Host "Install-Package Docker-Compose"
-# Choco-Install -PackageName docker-compose
+Write-Host "Install-Package Docker-Compose"
+Choco-Install -PackageName docker-compose
 
 $dockerImages = (Get-ToolsetContent).docker.images
 foreach ($dockerImage in $dockerImages) {
@@ -24,4 +23,4 @@ foreach ($dockerImage in $dockerImages) {
     }
 }
 
-# Invoke-PesterTests -TestFile "Docker"
+Invoke-PesterTests -TestFile "Docker"

--- a/images/win/scripts/Installers/Install-NET48.ps1
+++ b/images/win/scripts/Installers/Install-NET48.ps1
@@ -8,7 +8,6 @@ $InstallerName = "ndp48-devpack-enu.exe"
 $InstallerUrl = "https://download.visualstudio.microsoft.com/download/pr/014120d7-d689-4305-befd-3cb711108212/0307177e14752e359fde5423ab583e43/${InstallerName}"
 $ArgumentList = ("Setup", "/passive", "/norestart")
 
-# TO-DO: Will be fixed with https://github.com/actions/virtual-environments-internal/issues/2513
-# Install-Binary -Url $InstallerUrl -Name $InstallerName -ArgumentList $ArgumentList
+Install-Binary -Url $InstallerUrl -Name $InstallerName -ArgumentList $ArgumentList
 
-# Invoke-PesterTests -TestFile "Tools" -TestName "NET48"
+Invoke-PesterTests -TestFile "Tools" -TestName "NET48"

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -88,9 +88,8 @@ $markdown += New-MDList -Style Unordered -Lines (@(
     (Get-CabalVersion),
     (Get-CMakeVersion),
     (Get-CodeQLBundleVersion),
-    # TO-DO https://github.com/actions/virtual-environments-internal/issues/2512
-    # (Get-DockerVersion),
-    # (Get-DockerComposeVersion),
+    (Get-DockerVersion),
+    (Get-DockerComposeVersion),
     (Get-GHCVersion),
     (Get-GitVersion),
     (Get-GitLFSVersion),

--- a/images/win/scripts/Tests/Docker.Tests.ps1
+++ b/images/win/scripts/Tests/Docker.Tests.ps1
@@ -1,5 +1,4 @@
-# TO-DO: Will be fixed in https://github.com/actions/virtual-environments-internal/issues/2512
-Describe "Docker" -Skip:(Test-IsWin22) {
+Describe "Docker" {
     It "<ToolName>" -TestCases @(
         @{ ToolName = "docker" }
         @{ ToolName = "docker-compose" }

--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -48,7 +48,6 @@ Describe "DACFx" {
     }
 }
 
-# TO-DO
 Describe "DotnetTLS" -Skip:(Test-IsWin22) {
     It "Tls 1.2 is enabled" {
         [Net.ServicePointManager]::SecurityProtocol -band "Tls12" | Should -Be Tls12

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -159,7 +159,6 @@
             "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-KubernetesTools.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-VS.ps1",
-                "{{ template_dir }}/scripts/Installers/Install-NET48.ps1",
                 "{{ template_dir }}/scripts/Installers/Enable-DeveloperMode.ps1"
             ],
             "elevated_user": "{{user `install_user`}}",


### PR DESCRIPTION
- Enable Docker installation because enabling `Containers` component was fixed in the separate PR
- Disable `Install-NET48.ps1` script since NET 4.8 is already pre-installed on Windows Server 2022