### PR TITLE
Change .NET SDK pre-installation policy

### DIFF
--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -28,19 +28,15 @@ function Get-SDKVersionsToInstall (
         $sdks += $release.'sdks'
     }
 
-    $sdkVersions = @()
-    $sdks | ForEach-Object { $sdkVersions += $_.'version' }
-    $sortedSdkVersions = $sdkVersions | Sort-Object { [Version] $_ } -Unique
+    $sortedSdkVersions = $sdks.version | Sort-Object { [Version] $_ } -Unique
 
-    # return the latest patch version for every feature version
-    return $sortedSdkVersions | Where-Object {
-        $nextItemIndex = [array]::IndexOf($sortedSdkVersions, $_) + 1
-
-        if ($sortedSdkVersions.Length -eq $nextItemIndex) {
-            $true
-        } else {
-            $_.substring(0, 5) -ne ($sortedSdkVersions[$nextItemIndex]).substring(0, 5)
-        }
+    if (Test-IsWin22)
+    {
+        return $sortedSdkVersions | Group-Object { $_.substring(0, 5) } | Foreach-Object { $_.Group[-1] }
+    }
+    else 
+    {
+        return $sortedSdkVersions
     }
 }
 

--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -32,7 +32,7 @@ function Get-SDKVersionsToInstall (
 
     if (Test-IsWin22)
     {
-        return $sortedSdkVersions | Group-Object { $_.substring(0, 5) } | Foreach-Object { $_.Group[-1] }
+        return $sortedSdkVersions | Group-Object { $_.Substring(0, $_.LastIndexOf('.') + 2) } | Foreach-Object { $_.Group[-1] }
     }
     else 
     {

--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -34,10 +34,8 @@ function Get-SDKVersionsToInstall (
     {
         return $sortedSdkVersions | Group-Object { $_.Substring(0, $_.LastIndexOf('.') + 2) } | Foreach-Object { $_.Group[-1] }
     }
-    else 
-    {
-        return $sortedSdkVersions
-    }
+
+    return $sortedSdkVersions
 }
 
 function Invoke-Warmup (


### PR DESCRIPTION
Currently, we install all available and supported versions of .NET SDK (2.1.x, 3.1.x, 5.0.x). This pull request changes this approach in favor of installing the latest patch version for every feature version.

[Link to the build](https://github.visualstudio.com/virtual-environments/_build/results?buildId=114975&view=logs&j=011e1ec8-6569-5e69-4f06-baf193d1351e&t=5431112d-2b61-5a5f-7042-ef698f761043)